### PR TITLE
Allow deprecated functions.

### DIFF
--- a/linux/Makefile.combined
+++ b/linux/Makefile.combined
@@ -31,7 +31,7 @@ $(OBJ_DIR)/%.o: %.cpp $(HEADERS)
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -Wall $(LIBS) -o $@
+	$(CC) $(OBJECTS) -Wall -Wno-deprecated $(LIBS) -o $@
 
 build: $(TARGET)
     # GTK Specifics
@@ -53,7 +53,7 @@ build: $(TARGET)
     # The directory to install the resource files to.
     RESDIR = $(PREFIX)/share/openhome-player
 
-    CFLAGS = -c -Wall -std=c++11 $(GTK_CFLAGS)
+    CFLAGS = -c -Wall -std=c++11 $(GTK_CFLAGS) -Wno-deprecated
 
     ifeq ($(OSPLATFORM),ubuntu)
         # indicate to build that we have selected a valid target

--- a/linux/Makefile.raspbian
+++ b/linux/Makefile.raspbian
@@ -58,7 +58,7 @@ RESDIR = $(PREFIX)/share/openhome-player
 DOCDIR = $(PREFIX)/share/doc/openhome-player
 
 CFLAGS = -c -Wall -std=c++11 $(OPTIONAL_CFLAGS) -DTARG_ARCH=$(TARG_ARCH) \
-         -fstack-protector -fstack-check
+         -fstack-protector -fstack-check -Wno-deprecated
 
 # If 'DEBUG=0 is specified on the command line build a debug biuld.
 ifdef DEBUG

--- a/linux/Makefile.ubuntu
+++ b/linux/Makefile.ubuntu
@@ -50,7 +50,7 @@ RESDIR = $(PREFIX)/share/openhome-player
 DOCDIR = $(PREFIX)/share/doc/openhome-player
 
 CFLAGS = -c -Wall -std=c++11 $(PKG_CFLAGS) -DTARG_ARCH=$(TARG_ARCH) \
-         -DUSE_GTK -fstack-protector -fstack-check
+         -DUSE_GTK -fstack-protector -fstack-check -Wno-deprecated
 
 # If 'DEBUG=0 is specified on the command line build a debug biuld.
 ifdef DEBUG


### PR DESCRIPTION
This allows building against recent versions of `libgtk3`.
