### PR TITLE
Add headless mode.

### DIFF
--- a/README
+++ b/README
@@ -21,7 +21,7 @@ Linux (Ubuntu 12.x onward, Raspbian)
 
 # install compiler dependencies
 sudo apt-get update
-sudo apt-get install gcc-4.8 g++-4.8 
+sudo apt-get install gcc-4.8 g++-4.8
 
 # set up gcc alternates; we need gcc4.8
 
@@ -51,6 +51,10 @@ or
 make ubuntu-install     // build and install locally
 or
 make raspbian-install   // build and install locally
+
+If you need a headless version (without GUI that is) you can run
+
+make raspbian DISABLE_GTK=y
 
 # generate a debian package for distribution
 ./GeneratePkg.pl --platform=raspbian --application=openhome-player --version=0.1.2.3
@@ -90,5 +94,5 @@ Mac OSX (Mountain Lion onward)
 Open the Sample Xcode project and build release or debug variants.
 
    osx/OpenHomePlayer.xcodeproj
-   
+
 The project will build a system menu application.

--- a/linux/ConfigGTKKeyStore.cpp
+++ b/linux/ConfigGTKKeyStore.cpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include <gtk/gtk.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 

--- a/linux/ConfigGTKKeyStore.h
+++ b/linux/ConfigGTKKeyStore.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <gtk/gtk.h>
+#include <glib.h>
 
 #include <OpenHome/Configuration/BufferPtrCmp.h>
 #include <OpenHome/Configuration/IStore.h>

--- a/linux/ControlPointProxy.cpp
+++ b/linux/ControlPointProxy.cpp
@@ -1,4 +1,6 @@
+#ifdef USE_GTK
 #include <gtk/gtk.h>
+#endif
 
 #include <OpenHome/Av/Source.h>
 #include <OpenHome/Media/Pipeline/Msg.h>
@@ -169,7 +171,9 @@ void ControlPointProxy::CPPlaylist::transportChangedEvent()
     }
 
     // Adjust the UI accordingly.
+#ifdef USE_GTK
     gdk_threads_add_idle((GSourceFunc)updateUI, GINT_TO_POINTER(mediaOptions));
+#endif
 }
 
 void ControlPointProxy::CPPlaylist::setActive(TBool active)
@@ -317,7 +321,9 @@ void ControlPointProxy::CPRadio::transportChangedEvent()
     }
 
     // Adjust the UI accordingly.
+#ifdef USE_GTK
     gdk_threads_add_idle((GSourceFunc)updateUI, GINT_TO_POINTER(mediaOptions));
+#endif
 }
 
 void ControlPointProxy::CPRadio::setActive(TBool active)
@@ -443,7 +449,9 @@ void ControlPointProxy::CPReceiver::transportChangedEvent()
     }
 
     // Adjust the UI accordingly.
+#ifdef USE_GTK
     gdk_threads_add_idle((GSourceFunc)updateUI, GINT_TO_POINTER(mediaOptions));
+#endif
 }
 
 void ControlPointProxy::CPReceiver::setActive(TBool active)
@@ -570,7 +578,9 @@ void ControlPointProxy::CPUpnpAv::pipelineChangedEvent()
     }
 
     // Adjust the UI accordingly.
+#ifdef USE_GTK
     gdk_threads_add_idle((GSourceFunc)updateUI, GINT_TO_POINTER(mediaOptions));
+#endif
 }
 
 void ControlPointProxy::CPUpnpAv::setActive(TBool active)

--- a/linux/ExampleMediaPlayer.cpp
+++ b/linux/ExampleMediaPlayer.cpp
@@ -1,4 +1,4 @@
-#include <gtk/gtk.h>
+#include <glib.h>
 #include <string>
 
 #include <OpenHome/Media/Codec/CodecFactory.h>

--- a/linux/Makefile.raspbian
+++ b/linux/Makefile.raspbian
@@ -16,8 +16,19 @@
 OSPLATFORM=raspbian
 
 # GTK Specifics
+ifndef DISABLE_GTK
 GTK_CFLAGS := $(shell pkg-config --cflags gtk+-3.0)
 GTK_LIBS   := $(shell pkg-config --libs gtk+-3.0)
+
+OPTIONAL_CFLAGS = $(GTK_CFLAGS) -DUSE_GTK
+OPTIONAL_LIBS = $(GTK_LIBS) -lnotify
+else
+GLIB_CFLAGS := $(shell pkg-config --cflags glib-2.0)
+GLIB_LIBS   := $(shell pkg-config --libs glib-2.0)
+
+OPTIONAL_CFLAGS = $(GLIB_CFLAGS)
+OPTIONAL_LIBS = $(GLIB_LIBS)
+endif
 
 HWPLATFORM=$(shell uname -i)
 ifeq ($(HWPLATFORM),i686)
@@ -44,7 +55,7 @@ RESDIR = $(PREFIX)/share/openhome-player
 # The directory to install changelog and license to
 DOCDIR = $(PREFIX)/share/doc/openhome-player
 
-CFLAGS = -c -Wall -std=c++11 $(GTK_CFLAGS) -DTARG_ARCH=$(TARG_ARCH) \
+CFLAGS = -c -Wall -std=c++11 $(OPTIONAL_CFLAGS) -DTARG_ARCH=$(TARG_ARCH) \
          -fstack-protector -fstack-check
 
 # If 'DEBUG=0 is specified on the command line build a debug biuld.
@@ -66,7 +77,7 @@ else
     RESTRICTED_CODECS = -lCodecAdts -lCodecAac -lCodecAacBase -lCodecMp3
 endif
 
-LIBS         = $(GTK_LIBS) -lnotify -lasound -lSourcePlaylist -lSourceSongcast -lSourceUpnpAv -lSourceRadio -lShell -lohMediaPlayer -lWebAppFramework -lConfigUi -lohNetGeneratedProxies -lohNetCore $(RESTRICTED_CODECS) -lCodecAifc -lCodecAlac -lCodecAlacBase -lCodecPcm -lCodecAiff -lCodecAiffBase -lCodecVorbis -llibOgg -lCodecFlac -lCodecWav -lohPipeline -lpthread -lssl -lcrypto -ldl
+LIBS         = $(OPTIONAL_LIBS) -lasound -lSourcePlaylist -lSourceSongcast -lSourceUpnpAv -lSourceRadio -lShell -lohMediaPlayer -lWebAppFramework -lConfigUi -lohNetGeneratedProxies -lohNetCore $(RESTRICTED_CODECS) -lCodecAifc -lCodecAlac -lCodecAlacBase -lCodecPcm -lCodecAiff -lCodecAiffBase -lCodecVorbis -llibOgg -lCodecFlac -lCodecWav -lohPipeline -lpthread -lssl -lcrypto -ldl -lm
 
 INCLUDES     = -I../dependencies/$(TARG_ARCH)/ohMediaPlayer/include -I../dependencies/$(TARG_ARCH)/ohNetmon/include -I../dependencies/$(TARG_ARCH)/openssl/include -I../dependencies/$(TARG_ARCH)/ohNetGenerated-$(TARG_ARCH)-$(BUILD_TYPE)/include/ohnet/OpenHome/Net/Core
 
@@ -99,12 +110,12 @@ default: build $(TARGET)
 all: default
 
 $(OBJ_DIR)/%.o: %.cpp $(HEADERS)
-	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+	$(CXX) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -Wall $(LIBS) -o $@
+	$(CXX) $(OBJECTS) -Wall $(LIBS) -o $@
 
 build:
 	@mkdir -p $(OBJ_DIR)

--- a/linux/MediaPlayerIF.cpp
+++ b/linux/MediaPlayerIF.cpp
@@ -2,7 +2,11 @@
 // Extras to try and fix compiler errors
 // End of Extras
 
+#ifdef USE_GTK
 #include <gtk/gtk.h>
+#else
+#include <glib.h>
+#endif
 #include <unistd.h>
 
 #include <OpenHome/Net/Private/DviStack.h>
@@ -49,8 +53,10 @@ static gint tCallback(gpointer data)
             urlString[urlBuf.Bytes()] = '\0';
         }
 
+#ifdef USE_GTK
         gdk_threads_add_idle((GSourceFunc)updatesAvailable,
                              (gpointer)urlString);
+#endif
     }
 
     if (period == TenSeconds)

--- a/linux/OpenHomePlayer.h
+++ b/linux/OpenHomePlayer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glib.h>
+
 extern const gchar *g_appName;
 
 gboolean updateUI(gpointer mediaOptions);


### PR DESCRIPTION
Passing `DISABLE_GTK=y` to `make` arguments builds raspbian version without gtk (glib used instead where needed).
